### PR TITLE
Dispatch the site build with a token that resolves

### DIFF
--- a/.github/workflows/harmonize.yml
+++ b/.github/workflows/harmonize.yml
@@ -176,7 +176,32 @@ jobs:
         if: steps.check_changes.outputs.has_changes == 'true'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.DEPLOY_TOKEN }}
+          # AMMITTO_CI_PAT_TOKEN, not DEPLOY_TOKEN: no secret of the
+          # latter name exists. This repository has no repository-level
+          # secrets at all, and the organization secrets visible to it
+          # are AMMITTO_CI_PAT_TOKEN and AMMITTO_CI_RUBYGEMS_API_KEY --
+          # both checkable by name through the Actions secrets API,
+          # which returns names and never values. An undefined secret
+          # resolves to an empty string, and an explicitly empty input
+          # suppresses github-script's own default, so its
+          # core.getInput('github-token', {required: true}) raises
+          # "Input required and not supplied" before the script below is
+          # evaluated. The step does fail and the action's own handler
+          # logs it; what is missing is any connection to what this step
+          # is for. The message names an absent input, not a site that
+          # was never rebuilt, and the try/catch further down — which is
+          # inside the script — never sees it.
+          #
+          # Six sibling repos dispatch across repositories: data-uk,
+          # data-tr, data-jp, data-nz, data-eu-vessels and
+          # data-un-vessels. Every one of them names the secret this
+          # way, and this workflow was the seventh dispatcher and the
+          # only one still on DEPLOY_TOKEN. That is a census, not a
+          # recollection, and it is repeatable: grep every workflow in
+          # every ammitto repo for createWorkflowDispatch and read the
+          # secrets.* it references. Re-run it before trusting the
+          # count; a repo added since will not be in it.
+          github-token: ${{ secrets.AMMITTO_CI_PAT_TOKEN }}
           script: |
             try {
               await github.rest.actions.createWorkflowDispatch({


### PR DESCRIPTION
`Trigger website deployment` has never once succeeded. It has run 150 times, on every publish since February, and failed every time with:

```
Error: Input required and not supplied: github-token
    at Object.getInput (.../github-script/v7/dist/index.js:212:15)
```

**`secrets.DEPLOY_TOKEN` resolves to an empty string.** An explicitly empty input suppresses **`actions/github-script`**'s own `default: ${{ github.token }}`, so `core.getInput('github-token', {required: true})` raises before the `script:` body is evaluated. The `try/catch` lives inside that script, so it never sees the error: `Could not trigger deployment:` has never appeared as an output line in any run log, only as echoed source.

The failing step's `with:` echo carries no `github-token` line at all, while the next step in the same job echoes `github-token: ***`. The runner omits empty inputs and masks non-empty secrets, so that difference is the empty value showing itself.

Pointed it at **`AMMITTO_CI_PAT_TOKEN`** instead. Six sibling repos dispatch across repositories (data-uk, data-nz, data-tr, data-jp, data-eu-vessels, data-un-vessels) and all six use that name; the other eight use `GITHUB_TOKEN` because they never reach outside their own repo, which the built-in token cannot do. This repository dispatches to ammitto.github.io, so it needs the PAT.

## Test plan

Not testable from a branch: the step is unreachable until `Harmonize data` succeeds, and that has been failing since 22 July. Verified instead by comparison against a working control, `data-uk` run `32108582243` from today, which uses the same action and the same pattern with this secret name, echoes `github-token: ***`, and issues `POST .../actions/workflows/harmonize.yml/dispatches` successfully.

Self-verifying on merge: if the secret is not visible to this repository the step fails with the same message it fails with today, so the change cannot make matters worse. The first run after the harmonize gate passes will settle it either way.

## Not addressed here

The `try/catch` swallows a genuine dispatch failure and only logs it, so a token that is present but expired, revoked or under-scoped would leave the run green with the site never rebuilt. That is **#335**, not this: making a failed dispatch fail the run changes when this workflow reports failure, and belongs in its own pull request rather than riding along with a token name.

Worth separating from that, because an earlier draft of this body ran the two together: the failure fixed HERE was never silent. `core.getInput('github-token', {required: true})` raises, `main().catch(handleError)` in the action logs it and calls `core.setFailed`, so the step has failed loudly 150 times. What was missing is any connection between that message and this step's purpose — it names an absent input, not a site that was never rebuilt. Six months of nobody reading it is a different problem from a swallowed error, and the comment on the hunk now says so rather than claiming nothing was logged.

This also does not restore automatic deploys on its own. The dispatch sits after the harmonize step, which still fails on `ru`.

