### PR TITLE
Exempt ru from the health gate so the daily publish resumes

### DIFF
--- a/.github/workflows/harmonize.yml
+++ b/.github/workflows/harmonize.yml
@@ -146,8 +146,45 @@ jobs:
           mkdir -p api/v1/sources
           mkdir -p api/v1/schema
 
-          # Harmonize all sources with combined output
-          ammitto harmonize --all --sources-dir ./sources --output-dir ./api/v1 --combine --verbose
+          # ru is named in --allow-empty because it reaches the gate
+          # with no entity YAML to read, which is a source-level error,
+          # and the gate exits nonzero on it. Every step below is then
+          # skipped: a step's `if:` carries an implicit success() unless
+          # it spells out always(), failure() or cancelled(), so the
+          # has_changes conditions on the commit and the deployment
+          # dispatch narrow when those steps run but cannot make them run
+          # after a failure. One source with nothing to contribute
+          # therefore withholds the publish from every source that does,
+          # which is what has held this repository at the 2026-07-22
+          # commit.
+          #
+          # Read the exemption as broad, not surgical: for a named code
+          # it also clears the zero-entity, missing-aggregate and
+          # quality-floor gates, so a regression there will not be
+          # caught. Per-file transform errors are never exempt, for any
+          # code.
+          #
+          # The consequence worth naming: ru's per-source endpoint,
+          # api/v1/sources/ru.jsonld, stops being rewritten and keeps
+          # SERVING whatever it last held while the rest of the publish
+          # resumes around it. The exporter writes that file only when a
+          # source produced entities, and the client treats its presence
+          # as "this source exists" -- so ru reads as a healthy published
+          # source carrying July data, and grows relatively staler every
+          # day the others update. all.jsonld, search-index.json and
+          # stats.json are rebuilt from the current run and carry no ru
+          # rows, so the staleness is confined to that one endpoint.
+          # Accepted here because the alternative is publishing nothing
+          # at all; removing or suppressing the stale aggregate is its
+          # own change.
+          #
+          # un_vessels tripped the same gate until this morning and is
+          # deliberately not named: data-un-vessels#5 stopped .gitignore
+          # excluding its processed/ output, and the 06:21 fetch on
+          # 2026-08-19 committed 60 vessel files, so it clears the gate
+          # on its own. Drop ru the same way, the moment it has input.
+          ammitto harmonize --all --sources-dir ./sources --output-dir ./api/v1 --combine --verbose \
+            --allow-empty ru
 
       - name: Generate stats
         run: |


### PR DESCRIPTION
This repository has not published since the 2026-07-22 commit because one empty source withholds the run from the thirteen healthy ones. `ru` reaches the gate with no entity YAML to read, which is a source-level error, so **`ammitto harmonize`** exits nonzero; every step after it is then skipped, because a step's `if:` carries an implicit `success()` unless it spells out `always()`, `failure()` or `cancelled()`, and the `has_changes` conditions on the commit and the deployment dispatch narrow when those steps run without being able to make them run after a failure. Yesterday's scheduled run and five manual dispatches all died there.

Named `ru` in **`--allow-empty`**, with the reasoning in the workflow beside it: the exemption is broad rather than surgical, so for that code it also clears the zero-entity, missing-aggregate and quality-floor gates and a regression there will not be caught, and `ru`'s stale aggregate under `api/v1/sources` stops being rewritten and keeps whatever it last held. Per-file transform errors stay unexempt for every code, `ru` included. `un_vessels` tripped the same gate until this morning and is deliberately **not** named: ammitto/data-un-vessels#5 stopped `.gitignore` excluding its `processed/` output and the 06:21 fetch committed 60 vessel files, so it clears the gate on its own and never needs excusing.

Replaces #316, which carried the outage fix behind an unrelated 595-line rewrite of the failure-reporting step. This is that branch rebuilt from `main` as the change on its own.

Confirmed sufficient, not merely necessary. The 06:55 dispatched run on this repo today reported `14 succeeded, 1 failed, 0 exempted` with `ru: No YAML files found` as the only entry, `un_vessels` having cleared itself. Locally, the same fifteen sources with this flag exit **0**: `14 succeeded, 0 failed, 1 exempted`, 61,045 entities, `ru` listed under exempted rather than failed.

Verified: `exemptable_gate_failures` treats a source-level error as clearable (`harmonize_command.rb:215`) while `unconditional_gate_failures` covers only per-file transform errors (`:201`), and `spec/ammitto/cli/harmonize_command_spec.rb:883` already pins that an exempted errored source is reported exempted with no gate failure. Without the flag, `ammitto harmonize ru` against an empty `processed/` still exits 1.

---

Reviewed by Codex, not by Copilot: every Copilot request since 2026-08-18 15:20 returns "the user who requested the review has reached their quota limit", as a submitted review with zero comments. Recorded here so the review provenance is not assumed from the absence of comments.