### PR TITLE
Track one open issue for a harmonization outage instead of one per run

### DIFF
--- a/.github/scripts/harmonize_issue.sh
+++ b/.github/scripts/harmonize_issue.sh
@@ -83,6 +83,14 @@ if [ "$gates_passed" = "true" ]; then
   signature='healthy'
 else
   signature="$(printf '%s' "$failures" | tr '\n' ';' | sed 's/;$//')"
+  # A failing run that names no source means the producer changed shape or
+  # broke. Refusing is the point: an empty signature compares equal to the
+  # empty one already stored, so the unchanged path below would read it as
+  # "same outage as yesterday" and say nothing at all.
+  [ -n "$signature" ] || {
+    echo "report says the gates failed but lists no gate_failures" >&2
+    exit 65
+  }
 fi
 
 # Every open issue is fetched rather than searched: the marker lives in an

--- a/.github/scripts/harmonize_issue.sh
+++ b/.github/scripts/harmonize_issue.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Keep ONE open issue describing the current harmonization outage.
+#
+# Called by .github/workflows/harmonize.yml on every run, healthy or not.
+# Reads the JSON `ammitto harmonize --report` writes; it does not parse the
+# command's output. Parsing the log meant keying on the wording of a raised
+# Thor::Error, which the gem is free to change without warning.
+#
+# Why one issue
+# -------------
+# The step this replaces created an issue per failing run. That produced
+# 321 open issues carrying the `harmonization` label, the oldest from
+# February, and buried the outage it was reporting inside its own
+# duplicates. Nobody reads a channel that repeats itself daily.
+#
+# Identity is a BODY MARKER, never the title
+# ------------------------------------------
+# The issue is found by its body starting with $MARKER. Two consequences,
+# both deliberate:
+#
+#   - the 321 legacy issues carry the same labels and cannot be adopted,
+#     edited or closed from here, because none of them carries the marker;
+#   - a human may rename the issue and it stays tracked.
+#
+# State rides in the marker line rather than a repo file, because a failure
+# can happen before anything is committed and operational state does not
+# belong in the published dataset history.
+#
+# Only changes are announced
+# --------------------------
+# The signature is the sorted set of "code: reason" lines. Unchanged
+# signature means the same fault as yesterday and the script stays silent;
+# a different one means the shape of the outage moved and is worth a
+# comment; "healthy" means recovery, which comments and closes.
+#
+# Usage: harmonize_issue.sh <report.json> <run-url>
+# Environment:
+#   GH_TOKEN                        token with issues:write
+#   HARMONIZE_ISSUE_REPO            target repo (default $GITHUB_REPOSITORY)
+#   HARMONIZE_ALLOW_ISSUE_WRITE=1   permit writes outside GitHub Actions
+set -euo pipefail
+
+REPORT="${1:?usage: harmonize_issue.sh <report.json> <run-url>}"
+RUN_URL="${2:?usage: harmonize_issue.sh <report.json> <run-url>}"
+
+MARKER='<!-- harmonization-outage:v1 -->'
+SIGNATURE_PREFIX='<!-- harmonization-outage-signature: '
+SIGNATURE_SUFFIX=' -->'
+TITLE='Harmonization is failing'
+LABELS='automation,harmonization'
+# The schema this script knows how to read. A report stamped with anything
+# else is refused rather than guessed at, which is the whole point of
+# reporting instead of scraping.
+SCHEMA='ammitto-harmonize-report/v1'
+
+REPO="${HARMONIZE_ISSUE_REPO:-${GITHUB_REPOSITORY:-}}"
+
+[ -f "$REPORT" ] || { echo "report not found: $REPORT" >&2; exit 66; }
+[ -n "$REPO" ] || {
+  echo "no target repo: set GITHUB_REPOSITORY or HARMONIZE_ISSUE_REPO" >&2
+  exit 64
+}
+if [ "${GITHUB_ACTIONS:-}" != "true" ] &&
+   [ "${HARMONIZE_ALLOW_ISSUE_WRITE:-}" != "1" ]; then
+  echo "refusing to write issues outside GitHub Actions" \
+       "(set HARMONIZE_ALLOW_ISSUE_WRITE=1 to override)" >&2
+  exit 78
+fi
+
+schema="$(jq -r '.schema // ""' "$REPORT")"
+[ "$schema" = "$SCHEMA" ] || {
+  echo "unknown report schema ${schema:-(none)}; expected $SCHEMA" >&2
+  exit 65
+}
+
+gates_passed="$(jq -r '.gates_passed' "$REPORT")"
+# Sorted so that two runs failing on the same sources in a different order
+# read as the same fault rather than a new one.
+failures="$(jq -r '[.sources[] | select((.gate_failures | length) > 0)
+                   | .gate_failures[]] | sort | .[]' "$REPORT")"
+
+if [ "$gates_passed" = "true" ]; then
+  signature='healthy'
+else
+  signature="$(printf '%s' "$failures" | tr '\n' ';' | sed 's/;$//')"
+fi
+
+# Every open issue is fetched rather than searched: the marker lives in an
+# HTML comment, which the search index does not reliably see, and this repo
+# has 300+ open issues so the tracked one is not guaranteed to be on the
+# first page.
+open_json="$(gh api --paginate \
+  "repos/$REPO/issues?state=open&labels=harmonization&per_page=100" \
+  | jq -s 'add // []')"
+
+tracked="$(jq -r --arg m "$MARKER" \
+  '[.[] | select(has("pull_request") | not)
+        | select((.body // "") | startswith($m))]
+   | .[0].number // empty' <<<"$open_json")"
+
+old_signature=''
+if [ -n "$tracked" ]; then
+  old_signature="$(jq -r --arg m "$MARKER" --arg p "$SIGNATURE_PREFIX" \
+    '[.[] | select(has("pull_request") | not)
+          | select((.body // "") | startswith($m))] | .[0].body // ""' \
+    <<<"$open_json" \
+    | sed -n "s/.*${SIGNATURE_PREFIX}\(.*\)${SIGNATURE_SUFFIX}.*/\1/p" \
+    | head -n 1)"
+fi
+
+body_file="$(mktemp)"
+trap 'rm -f "$body_file"' EXIT
+
+write_body() {
+  {
+    printf '%s\n' "$MARKER"
+    printf '%s%s%s\n\n' "$SIGNATURE_PREFIX" "$signature" "$SIGNATURE_SUFFIX"
+    printf 'Harmonization has been failing since this issue was opened. '
+    printf 'It is updated in place rather than reopened per run, and closes '
+    printf 'itself when a run succeeds.\n\n'
+    printf 'Latest failing run: %s\n\n' "$RUN_URL"
+    printf '| Source | Gate failure |\n| --- | --- |\n'
+    jq -r '.sources[] | select((.gate_failures | length) > 0)
+           | . as $s | .gate_failures[]
+           | "| `\($s.code)` | \(. | gsub("[|]"; "\\|")) |"' "$REPORT"
+    printf '\n%s succeeded, %s failed, %s exempted.\n' \
+      "$(jq -r '.counts.succeeded' "$REPORT")" \
+      "$(jq -r '.counts.failed' "$REPORT")" \
+      "$(jq -r '.counts.exempted' "$REPORT")"
+  } > "$body_file"
+}
+
+# The unchanged check comes FIRST, before the healthy/failing split.
+# Ordering it the other way makes a healthy repo with an open issue comment
+# "recovered" and close it on every single run.
+if [ -z "$tracked" ]; then
+  if [ "$signature" = 'healthy' ]; then
+    echo 'harmonize healthy, no open tracking issue — nothing to announce'
+    exit 0
+  fi
+  write_body
+  gh issue create --repo "$REPO" --title "$TITLE" \
+    --label "$LABELS" --body-file "$body_file"
+  echo "opened tracking issue for: $signature"
+  exit 0
+fi
+
+if [ "$old_signature" = "$signature" ]; then
+  echo "no change since the last announcement ($signature) — staying quiet"
+  exit 0
+fi
+
+if [ "$signature" = 'healthy' ]; then
+  gh issue comment "$tracked" --repo "$REPO" \
+    --body "Recovered. Harmonization succeeded in $RUN_URL. Closing; a new outage opens a fresh issue."
+  gh issue close "$tracked" --repo "$REPO"
+  echo "recovered — commented and closed #$tracked"
+  exit 0
+fi
+
+write_body
+gh issue comment "$tracked" --repo "$REPO" --body-file "$body_file"
+gh issue edit "$tracked" --repo "$REPO" --body-file "$body_file"
+echo "signature changed on #$tracked: '${old_signature:-none}' -> '$signature'"

--- a/.github/scripts/harmonize_issue_test.sh
+++ b/.github/scripts/harmonize_issue_test.sh
@@ -134,6 +134,9 @@ issues "$(tracked_issue 'ru: No YAML files found')"
 report "$WORK/report.json" true
 out="$(run)"
 check 'closes on recovery' 'commented and closed #400' "$out"
+# Asserted separately from the summary line, which would keep saying
+# "commented and closed" after the comment call was removed.
+check 'comments before closing' 'issue comment 400' "$(cat "$WORK/calls")"
 check 'actually closes' 'issue close 400' "$(cat "$WORK/calls")"
 
 # The 321 legacy issues carry the labels but no marker. Adopting one would
@@ -166,6 +169,13 @@ check 'carries the marker first' '<!-- harmonization-outage:v1 -->' \
   "$(head -n 1 "$WORK/last_body")"
 check 'carries the signature' 'harmonization-outage-signature: ru: transform' \
   "$(cat "$WORK/last_body")"
+
+# A failing run naming no source is a broken producer, and must not be
+# mistaken for the same outage as yesterday.
+issues "$(tracked_issue '')"
+report "$WORK/report.json" false
+out="$(run)"
+check 'refuses a failing report with no failures' 'lists no gate_failures' "$out"
 
 # A missing report is a broken caller, not a healthy run.
 rm -f "$WORK/report.json"

--- a/.github/scripts/harmonize_issue_test.sh
+++ b/.github/scripts/harmonize_issue_test.sh
@@ -100,7 +100,11 @@ issues '[]'
 report "$WORK/report.json" true
 out="$(run)"
 check 'silent when healthy and untracked' 'nothing to announce' "$out"
-check 'writes nothing' '' "$(grep -c 'issue create' "$WORK/calls" || true)0"
+# Counted, not substring-matched: check() passes when the actual string
+# CONTAINS the expected one, so an empty expectation passes against
+# anything and this assertion could never fail.
+check 'writes nothing' 'writes=0' \
+  "writes=$(grep -cE 'issue (create|comment|edit|close)' "$WORK/calls" || true)"
 
 # The same fault tomorrow says nothing: this is what stops 321 duplicates.
 issues "$(tracked_issue 'ru: No YAML files found')"

--- a/.github/scripts/harmonize_issue_test.sh
+++ b/.github/scripts/harmonize_issue_test.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Offline proof of harmonize_issue.sh's state machine.
+#
+# Runs before the live step in the workflow, for the same reason the fleet
+# monitor self-tests: a reconciler whose parsing silently broke would report
+# "nothing to announce" forever, which is the exact failure the issue
+# tracking exists to prevent. Costs well under a second and makes no API
+# call — `gh` is replaced by a stub that records its arguments and replays
+# a fixture.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/harmonize_issue.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+
+# --- the stub -------------------------------------------------------------
+# $WORK/issues.json is what `gh api --paginate .../issues` replays.
+# $WORK/calls records every `gh` invocation, one per line, so an assertion
+# can state what the script did and not merely what it printed.
+mkdir -p "$WORK/bin"
+cat > "$WORK/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$WORK/calls"
+# Keep whatever body was written, so an assertion can read the rendered
+# issue and not merely the fact that a call happened.
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "--body-file" ]; then cp "$arg" "$WORK/last_body"; fi
+  prev="$arg"
+done
+case "$1" in
+  api) cat "$WORK/issues.json" ;;
+  *)   : ;;
+esac
+STUB
+chmod +x "$WORK/bin/gh"
+export PATH="$WORK/bin:$PATH"
+export WORK
+export HARMONIZE_ISSUE_REPO='ammitto/data'
+export HARMONIZE_ALLOW_ISSUE_WRITE=1
+
+report() { # <path> <gates_passed> [failure...]
+  local path="$1" passed="$2"
+  shift 2
+  local sources='[]'
+  for f in "$@"; do
+    local code="${f%%:*}"
+    sources="$(jq -c --arg c "$code" --arg r "$f" \
+      '. + [{code: $c, status: "error", entities: null, entries: null,
+             error: $r, gate_failures: [$r], exempted_failures: [],
+             transform_errors: [], quality: {}}]' <<<"$sources")"
+  done
+  jq -n --argjson passed "$passed" --argjson sources "$sources" \
+    '{schema: "ammitto-harmonize-report/v1",
+      generated_at: "2026-08-19T09:00:00Z",
+      gates_passed: $passed,
+      counts: {succeeded: 13, failed: ($sources | length), exempted: 0},
+      totals: {entities: 61048, entries: 61048},
+      sources: $sources}' > "$path"
+}
+
+issues() { printf '%s' "$1" > "$WORK/issues.json"; }
+
+tracked_issue() { # <signature>
+  jq -n --arg s "$1" \
+    '[{number: 400, body: ("<!-- harmonization-outage:v1 -->\n" +
+        "<!-- harmonization-outage-signature: " + $s + " -->\n\nbody")}]'
+}
+
+check() { # <name> <expected-substring> <actual>
+  if [[ "$3" == *"$2"* ]]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    printf 'FAIL %s\n  expected to contain: %s\n  got: %s\n' "$1" "$2" "$3" >&2
+  fi
+}
+
+run() { # -> stdout, with $WORK/calls reset
+  : > "$WORK/calls"
+  "$SCRIPT" "$WORK/report.json" 'https://run/1' 2>&1 || echo "EXIT=$?"
+}
+
+# --- cases ----------------------------------------------------------------
+
+# A first failure opens the issue. The original defect was duplication, not
+# the existence of a first alert.
+issues '[]'
+report "$WORK/report.json" false 'ru: No YAML files found'
+out="$(run)"
+check 'opens on first failure' 'opened tracking issue' "$out"
+check 'creates rather than comments' 'issue create' "$(cat "$WORK/calls")"
+
+# A healthy run with nothing open must not create anything at all.
+issues '[]'
+report "$WORK/report.json" true
+out="$(run)"
+check 'silent when healthy and untracked' 'nothing to announce' "$out"
+check 'writes nothing' '' "$(grep -c 'issue create' "$WORK/calls" || true)0"
+
+# The same fault tomorrow says nothing: this is what stops 321 duplicates.
+issues "$(tracked_issue 'ru: No YAML files found')"
+report "$WORK/report.json" false 'ru: No YAML files found'
+out="$(run)"
+check 'quiet when unchanged' 'staying quiet' "$out"
+[ -s "$WORK/calls" ] && grep -q 'issue comment' "$WORK/calls" &&
+  { echo 'FAIL commented on an unchanged signature' >&2; FAIL=$((FAIL + 1)); }
+
+# A second source failing changes the shape of the outage and is worth
+# saying, on the issue that already exists.
+issues "$(tracked_issue 'ru: No YAML files found')"
+report "$WORK/report.json" false 'ru: No YAML files found' \
+  'jp: produced 0 entities'
+out="$(run)"
+check 'announces a changed signature' 'signature changed on #400' "$out"
+check 'comments on the tracked issue' 'issue comment 400' "$(cat "$WORK/calls")"
+check 'and rewrites its body' 'issue edit 400' "$(cat "$WORK/calls")"
+
+# Order must not matter, or a run reporting the same two sources the other
+# way round would read as a new fault every day.
+issues "$(tracked_issue 'jp: produced 0 entities;ru: No YAML files found')"
+report "$WORK/report.json" false 'ru: No YAML files found' \
+  'jp: produced 0 entities'
+out="$(run)"
+check 'signature is order-independent' 'staying quiet' "$out"
+
+# Recovery closes it. An open issue titled "failing" over a healthy repo is
+# the same lie the duplicates were.
+issues "$(tracked_issue 'ru: No YAML files found')"
+report "$WORK/report.json" true
+out="$(run)"
+check 'closes on recovery' 'commented and closed #400' "$out"
+check 'actually closes' 'issue close 400' "$(cat "$WORK/calls")"
+
+# The 321 legacy issues carry the labels but no marker. Adopting one would
+# mean editing an issue this automation did not open.
+issues '[{"number": 12, "body": "The harmonization workflow failed. See: ..."}]'
+report "$WORK/report.json" false 'ru: No YAML files found'
+out="$(run)"
+check 'never adopts an unmarked issue' 'opened tracking issue' "$out"
+check 'opens its own instead' 'issue create' "$(cat "$WORK/calls")"
+
+# A pull request can carry the same labels and shares the issues listing.
+issues '[{"number": 99, "pull_request": {}, "body": "<!-- harmonization-outage:v1 -->\nx"}]'
+report "$WORK/report.json" false 'ru: No YAML files found'
+out="$(run)"
+check 'ignores pull requests' 'opened tracking issue' "$out"
+
+# An unrecognised schema is refused rather than guessed at.
+jq -n '{schema: "something-else/v9", gates_passed: false, sources: []}' \
+  > "$WORK/report.json"
+out="$(run)"
+check 'refuses an unknown schema' 'unknown report schema' "$out"
+
+# A reason containing a pipe must not break the table it is rendered in.
+issues '[]'
+report "$WORK/report.json" false 'ru: transform failed on a|b'
+run > /dev/null
+check 'escapes a pipe in the rendered table' 'a\|b' "$(cat "$WORK/last_body")"
+check 'renders one row per failure' '| `ru` |' "$(cat "$WORK/last_body")"
+check 'carries the marker first' '<!-- harmonization-outage:v1 -->' \
+  "$(head -n 1 "$WORK/last_body")"
+check 'carries the signature' 'harmonization-outage-signature: ru: transform' \
+  "$(cat "$WORK/last_body")"
+
+# A missing report is a broken caller, not a healthy run.
+rm -f "$WORK/report.json"
+out="$(run)"
+check 'refuses a missing report' 'report not found' "$out"
+
+printf '%d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/.github/workflows/harmonize.yml
+++ b/.github/workflows/harmonize.yml
@@ -23,6 +23,14 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Offline fixture proof of the reconciler's state machine, ahead of
+      # the work, because a reconciler that silently stopped recognising
+      # its own issue would go quiet rather than fail. Costs under a
+      # second and makes no API call.
+      - name: Self-test the outage reconciler
+        id: reconciler_selftest
+        run: .github/scripts/harmonize_issue_test.sh
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -183,8 +191,14 @@ jobs:
           # excluding its processed/ output, and the 06:21 fetch on
           # 2026-08-19 committed 60 vessel files, so it clears the gate
           # on its own. Drop ru the same way, the moment it has input.
-          ammitto harmonize --all --sources-dir ./sources --output-dir ./api/v1 --combine --verbose \
-            --allow-empty ru
+          #
+          # The report is written outside the working tree on purpose:
+          # the commit step below runs `git add .` and would publish it.
+          # It is written even when the gates fail, which is the run the
+          # reconciler below needs it for.
+          ammitto harmonize --all --sources-dir ./sources --output-dir ./api/v1 \
+            --combine --verbose --allow-empty ru \
+            --report "$RUNNER_TEMP/harmonize-report.json"
 
       - name: Generate stats
         run: |
@@ -259,15 +273,19 @@ jobs:
               core.setFailed('Could not trigger deployment: ' + error.message);
             }
 
-      - name: Create issue on failure
-        if: failure()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: 'Harmonization failed - ${{ github.run_id }}',
-              body: 'The harmonization workflow failed. See: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}',
-              labels: ['automation', 'harmonization']
-            })
+      # One open issue carries the state of the current outage, updated in
+      # place and closed on recovery. The step this replaces created one
+      # per failing run, which is how 321 open issues accumulated and
+      # buried the outage they were reporting.
+      #
+      # `job.status` is not the input: the reconciler reads the JSON report
+      # harmonize wrote, so it can say which sources failed and why rather
+      # than only that something did.
+      - name: Reconcile the harmonization outage issue
+        if: ${{ !cancelled() && steps.reconciler_selftest.outcome == 'success' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          .github/scripts/harmonize_issue.sh \
+            "$RUNNER_TEMP/harmonize-report.json" \
+            "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"

--- a/.github/workflows/harmonize.yml
+++ b/.github/workflows/harmonize.yml
@@ -268,8 +268,16 @@ jobs:
               // expired, revoked or under-scoped raises HERE, and
               // console.log left the run green: the data was published
               // and the site was never rebuilt, with nothing saying so.
-              // Failing hands it to the issue step below, which is the
-              // only thing that tells anyone.
+              // Failing makes the run red, and that is the whole signal.
+              //
+              // It deliberately does NOT reach the reconciler below.
+              // That step tracks the harmonization outage and keys on
+              // the report harmonize wrote, so a run whose sources were
+              // all healthy reads as healthy there however the dispatch
+              // went. A dispatch that never fired is a different fault
+              // from a source that produced nothing, and folding the
+              // two onto one issue is what the reconciler exists to
+              // stop.
               core.setFailed('Could not trigger deployment: ' + error.message);
             }
 


### PR DESCRIPTION
The failure step opened an issue per failing run, so this repository carries **321 open issues** with the `harmonization` label, the oldest from February, and the outage they report is buried inside its own duplicates. Replacing that means answering what a per-run issue could not: is this the same fault as yesterday, and has it cleared?

**`.github/scripts/harmonize_issue.sh`** keeps one open issue, updated in place and closed when a run succeeds. It reads the JSON from `ammitto harmonize --report` rather than the command's output: the previous approach in #317 regexed stdout for `Harmonize health gate failed:`, which is the wording of a raised `Thor::Error` and something the gem is free to change without warning. Identity is a **body marker**, never the title, so a human can rename the issue and it stays tracked while none of the 321 legacy issues can ever be adopted, edited or closed from here. It announces only changes: the signature is the sorted set of `code: reason` lines, so the same fault tomorrow is silent, a different one comments, and recovery closes. Every open labelled issue is paginated rather than searched, because the marker lives in an HTML comment the search index does not reliably see and the tracked issue is not guaranteed to sit on the first page of 321.

**`.github/scripts/harmonize_issue_test.sh`** proves that state machine offline against a stubbed `gh`, and runs as the first step of the job. A reconciler that stopped recognising its own issue would go quiet rather than fail, which is precisely the failure this exists to prevent, so the live step is gated on the self-test passing. It costs under a second and makes no API call.

Supersedes #317, which put 595 lines of JavaScript inside the YAML. The workflow grows from 203 lines to 219 here rather than to 854, and the logic sits in files that can be read, linted and run. The escalation machinery #317 also carried — fault fingerprints, transient bucketing, failure-family classification, day and run thresholds, seen-signature history — is deliberately not carried over: the defect was duplication, and that is a separate decision to take on its own evidence.

Depends on ammitto/ammitto#60, which adds `--report`. Until it merges, harmonize would reject the flag.

Rebased onto main now that #331 has merged. The two did conflict on the harmonize command line, as measured; the resolution keeps both sides in full — #331's comment block on why `ru` is exempted and what the stale `api/v1/sources/ru.jsonld` endpoint costs, this branch's comment on why the report path sits outside the working tree, and one invocation carrying `--allow-empty ru` and `--report` together. The workflow still parses and the self-test still passes 22 assertions after the rebase.

The producer side, ammitto/ammitto#60, is merged, so `harmonize --report` exists on the gem's main rather than being a seam this branch anticipates.

A review round closed two holes, both of the same kind: something going quiet where it should speak. A run reporting `gates_passed: false` while naming no source produced an empty signature, which compares equal to the empty one already stored, so a broken producer would have read as "same outage as yesterday" and said nothing; that is now refused with exit 65. And the recovery case asserted only the script's own summary line, so removing the recovery comment while leaving `echo "commented and closed"` in place would have passed; the call is asserted directly now.

Run against a real report as well as its fixtures, because a fixture can agree with itself: pointed at the 6,168-byte JSON a live fifteen-source `--report` run produced, with `gh` stubbed, it opens one issue whose signature reads `ru: No YAML files found;un_vessels: No YAML files found` and renders a two-row table naming both.

A later round found one of those 22 assertions could not fail: `check` tests containment and `writes nothing` passed it an empty expected string, so it accepted anything. It counts write subcommands now — `writes=0` against `grep -cE 'issue (create|comment|edit|close)'`, which is every mutating `gh` call the script makes; `gh api` is the only other one and it reads. A mutant that makes the healthy-and-untracked path create an issue while printing the same line fails exactly that one assertion; against the old form the same mutant passed 22 of 22.

The report contract is checked against the gem rather than assumed: `report_payload` and `report_source` on the merged main write every field the reconciler's jq reads, and `REPORT_SCHEMA` is byte-identical to `SCHEMA` here.

Merge after #324. #324 changes the dispatch step in this same file and this branch does not carry that change, so landing them the other way round leaves a conflict to resolve by hand in the neighbouring step.

Verified: the self-test passes 22 assertions, and it fails when the logic is broken rather than only when it is absent — removing the unchanged-signature short circuit fails 3, matching any labelled issue instead of the marker fails 2, dropping the sort from the signature fails 1, reverting the table's pipe escaping fails 1, dropping the recovery comment fails 1, and removing the empty-signature guard fails 1. The workflow parses. Nothing about the harmonize, stats, commit or deployment steps changes beyond the report flag, and the report is written to `$RUNNER_TEMP` so `git add .` cannot publish it.

---

Reviewed by Codex, not by Copilot: every Copilot request since 2026-08-18 15:20 returns "the user who requested the review has reached their quota limit", as a submitted review with zero comments. Recorded here so the review provenance is not assumed from the absence of comments.

