### PR TITLE
Fail the run when the dispatch it exists to make does not happen

### DIFF
--- a/.github/workflows/harmonize.yml
+++ b/.github/workflows/harmonize.yml
@@ -248,7 +248,15 @@ jobs:
                 ref: 'main'
               });
             } catch (error) {
-              console.log('Could not trigger deployment: ' + error.message);
+              // Fails the step rather than logging and carrying on. The
+              // empty-token case above is caught by the action before
+              // this script runs, but a token that is present and
+              // expired, revoked or under-scoped raises HERE, and
+              // console.log left the run green: the data was published
+              // and the site was never rebuilt, with nothing saying so.
+              // Failing hands it to the issue step below, which is the
+              // only thing that tells anyone.
+              core.setFailed('Could not trigger deployment: ' + error.message);
             }
 
       - name: Create issue on failure


### PR DESCRIPTION
The step that dispatches the site build wraps `createWorkflowDispatch` in a `try/catch` whose `catch` calls `console.log` and returns. A token that is present but expired, revoked or under-scoped raises there, so the data is committed and pushed, the site is never rebuilt, and the run finishes **green** with one line buried in the step's log. That is the same shape as the fault that held this repository at the 2026-07-22 commit for 28 days: not a failure that went unfixed, but a failure that was never reported.

The empty-token case is already loud and is a different mechanism: an explicitly empty `github-token` input suppresses `actions/github-script`'s own default, so the action raises "Input required and not supplied" before the script body is evaluated and the `catch` never sees it. #324 fixes that one by naming the secret that actually resolves. This one is about the case that reaches the script.

`core.setFailed` rather than `console.log`, so the step fails and `Create issue on failure` — which is guarded by `if: failure()` — actually runs. Nothing else in the job changes: the commit has already happened by then and is not rolled back, and there are no ordinary steps after the dispatch to skip.

## Test plan

There is nothing to unit test in a two-line `catch`; what is verifiable is the shape. `yaml.safe_load` parses the file. `core` is in scope in an `actions/github-script@v7` script body and `setFailed` sets a failing exit code for the step, which is what makes `failure()` true for the step below — checked against the action's README and the `@actions/core` contract rather than assumed.

## Scope

Split out of #324 deliberately. #324's own body says this "belongs in its own pull request rather than riding along with a token name", and that was right: changing **when this workflow reports failure** is a separate decision from naming the secret it authenticates with. #324 is unchanged and still merges on its own.

Merge order: this sits on top of #324 conceptually but not textually — both touch the same step, so whichever lands second needs a trivial rebase. #332 is also open against this file.
